### PR TITLE
Add configurable API base

### DIFF
--- a/lentil-life/README.md
+++ b/lentil-life/README.md
@@ -56,6 +56,11 @@ npm run dev
 ```
 
 The frontend should now be running at http://localhost:5173 and the backend at http://localhost:4000.
+If your backend runs on a different URL, create a `.env` file inside `frontend` with:
+
+```
+VITE_API_URL=http://your-backend-domain/api
+```
 
 ## Features
 

--- a/lentil-life/SETUP.md
+++ b/lentil-life/SETUP.md
@@ -43,6 +43,11 @@ cd backend
 npm run dev
 ```
 This will start the backend server on http://localhost:4000
+The frontend expects the backend URL in `frontend/.env`. If you use a different URL, set:
+
+```
+VITE_API_URL=http://your-backend-domain/api
+```
 
 ### Method 2: Using Concurrently (Optional)
 

--- a/lentil-life/frontend/.env.example
+++ b/lentil-life/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:4000/api

--- a/lentil-life/frontend/src/App.tsx
+++ b/lentil-life/frontend/src/App.tsx
@@ -26,9 +26,7 @@ import AdminDashboardPage from './pages/AdminDashboardPage';
 import AdminPaymentSettingsPage from './pages/AdminPaymentSettingsPage.tsx';
 import NotFoundPage from './pages/NotFoundPage';
 import PrivateRoute from './components/PrivateRoute';
-
-// Define API URL for use throughout the app
-export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
+import { API_URL } from './config';
 
 function App() {
   // Initially, user is not scrolled, so promo banner space is visible.

--- a/lentil-life/frontend/src/components/PickupTimeSelector.tsx
+++ b/lentil-life/frontend/src/components/PickupTimeSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Calendar, Clock, AlertCircle } from 'lucide-react';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 
 interface TimeSlot {
   id: string;

--- a/lentil-life/frontend/src/components/PointsCalculator.tsx
+++ b/lentil-life/frontend/src/components/PointsCalculator.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Star, Info } from 'lucide-react';
+import { API_URL } from '../config';
 
 interface PointsCalculatorProps {
   orderAmount: number;
@@ -33,7 +34,7 @@ const PointsCalculator: React.FC<PointsCalculatorProps> = ({
 
   const fetchPointsConfig = async () => {
     try {
-      const response = await fetch('http://localhost:4000/api/points/config');
+      const response = await fetch(`${API_URL}/points/config`);
       const data = await response.json();
       
       if (data.success) {
@@ -48,7 +49,7 @@ const PointsCalculator: React.FC<PointsCalculatorProps> = ({
 
   const calculatePoints = async () => {
     try {
-      const response = await fetch(`http://localhost:4000/api/points/calculate?amount=${orderAmount}`);
+      const response = await fetch(`${API_URL}/points/calculate?amount=${orderAmount}`);
       const data = await response.json();
       
       if (data.success) {

--- a/lentil-life/frontend/src/components/PointsDisplay.tsx
+++ b/lentil-life/frontend/src/components/PointsDisplay.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Star, Gift, Clock, TrendingUp, Award } from 'lucide-react';
+import { API_URL } from '../config';
 
 interface PointsTransaction {
   id: string;
@@ -53,7 +54,7 @@ const PointsDisplay: React.FC<PointsDisplayProps> = ({
 
   const fetchUserPoints = async () => {
     try {
-      const response = await fetch(`http://localhost:4000/api/points/user/${userId}`);
+      const response = await fetch(`${API_URL}/points/user/${userId}`);
       const data = await response.json();
       
       if (data.success) {
@@ -69,7 +70,7 @@ const PointsDisplay: React.FC<PointsDisplayProps> = ({
 
   const fetchPointsHistory = async () => {
     try {
-      const response = await fetch(`http://localhost:4000/api/points/user/${userId}/history?limit=10`);
+      const response = await fetch(`${API_URL}/points/user/${userId}/history?limit=10`);
       const data = await response.json();
       
       if (data.success) {
@@ -82,7 +83,7 @@ const PointsDisplay: React.FC<PointsDisplayProps> = ({
 
   const fetchPointsConfig = async () => {
     try {
-      const response = await fetch('http://localhost:4000/api/points/config');
+      const response = await fetch(`${API_URL}/points/config`);
       const data = await response.json();
       
       if (data.success) {

--- a/lentil-life/frontend/src/config.ts
+++ b/lentil-life/frontend/src/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';

--- a/lentil-life/frontend/src/context/AuthContext.tsx
+++ b/lentil-life/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { API_URL } from '../config';
 
 // Types
 interface User {
@@ -94,9 +95,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [isLoading, setIsLoading] = useState(true);
 
   // API base URL
-  const API_BASE = process.env.NODE_ENV === 'production' 
-    ? 'https://your-domain.com/api' 
-    : 'http://localhost:4000/api';
+  const API_BASE = API_URL;
 
   // Check for existing session on app load
   useEffect(() => {

--- a/lentil-life/frontend/src/context/PaymentContext.tsx
+++ b/lentil-life/frontend/src/context/PaymentContext.tsx
@@ -1,8 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { loadStripe, Stripe } from '@stripe/stripe-js';
 import axios, { AxiosError } from 'axios';
-
-const API_URL = 'http://localhost:4000/api';
+import { API_URL } from '../config';
 
 interface PaymentConfig {
   stripePublishableKey: string;

--- a/lentil-life/frontend/src/pages/AdminBackupPage.tsx
+++ b/lentil-life/frontend/src/pages/AdminBackupPage.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 
 interface Backup {
   id: string;

--- a/lentil-life/frontend/src/pages/AdminDashboardPage.tsx
+++ b/lentil-life/frontend/src/pages/AdminDashboardPage.tsx
@@ -10,7 +10,7 @@ import {
   Calendar,
   Package
 } from 'lucide-react';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 import AdminSidebar from '../components/AdminSidebar';
 
 interface OrderItem {

--- a/lentil-life/frontend/src/pages/AdminMenuPage.tsx
+++ b/lentil-life/frontend/src/pages/AdminMenuPage.tsx
@@ -20,7 +20,7 @@ import {
   ShoppingBag
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 import { resizeImageBeforeUpload } from '../utils/imageService';
 import OptimizedImage from '../components/OptimizedImage';
 

--- a/lentil-life/frontend/src/pages/AdminOrdersPage.tsx
+++ b/lentil-life/frontend/src/pages/AdminOrdersPage.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 
 // Define order status type
 type OrderStatus = 'pending' | 'processing' | 'completed' | 'delivered' | 'cancelled' | 'Pending Venmo Payment' | 'Venmo Payment Completed' | 'Cash on Pickup' | 'Pending Cash Payment';

--- a/lentil-life/frontend/src/pages/AdminPaymentSettingsPage.tsx
+++ b/lentil-life/frontend/src/pages/AdminPaymentSettingsPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Save, AlertCircle, RefreshCw, Image as ImageIcon, AtSign } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 import AdminSidebar from '../components/AdminSidebar';
 
 interface PaymentSettings {

--- a/lentil-life/frontend/src/pages/AdminTimeSlotPage.tsx
+++ b/lentil-life/frontend/src/pages/AdminTimeSlotPage.tsx
@@ -13,7 +13,7 @@ import {
   RefreshCw
 } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 
 interface TimeSlot {
   id: string;

--- a/lentil-life/frontend/src/pages/CartPage.tsx
+++ b/lentil-life/frontend/src/pages/CartPage.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import { Trash2, Plus, Minus, ArrowLeft, Check } from 'lucide-react';
 import { useCart } from '../context/CartContext';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 import PickupTimeSelector from '../components/PickupTimeSelector';
 import PointsCalculator from '../components/PointsCalculator';
 

--- a/lentil-life/frontend/src/pages/HomePage.tsx
+++ b/lentil-life/frontend/src/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Hero from '../components/Hero';
 import { Link } from 'react-router-dom';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 import { MenuItem } from '../types';
 
 const HomePage: React.FC = () => {

--- a/lentil-life/frontend/src/pages/OrdersPage.tsx
+++ b/lentil-life/frontend/src/pages/OrdersPage.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { Package, Clock, CheckCircle, XCircle, Calendar, DollarSign } from 'lucide-react';
+import { API_URL } from '../config';
 
 interface Order {
   id: string;
@@ -41,7 +42,7 @@ const OrdersPage: React.FC = () => {
 
   const fetchOrders = async () => {
     try {
-      const response = await fetch('http://localhost:4000/api/orders', {
+      const response = await fetch(`${API_URL}/orders`, {
         credentials: 'include',
       });
 

--- a/lentil-life/frontend/src/pages/ProductPage.tsx
+++ b/lentil-life/frontend/src/pages/ProductPage.tsx
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet-async';
 import { ArrowLeft, Plus, Minus, ChevronDown, ChevronUp, Star } from 'lucide-react';
 import { useCart } from '../context/CartContext';
 import { MenuItem } from '../types';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 
 const ProductPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();

--- a/lentil-life/frontend/src/pages/ShopPage.tsx
+++ b/lentil-life/frontend/src/pages/ShopPage.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 // import { menuItems } from '../data/menuData';
 import { MenuItem as MenuItemType } from '../types';
 import AddToCartButton from '../components/AddToCartButton';
-import { API_URL } from '../App';
+import { API_URL } from '../config';
 
 // Define API URL
 // const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000/api';

--- a/lentil-life/frontend/src/pages/SignupPage.tsx
+++ b/lentil-life/frontend/src/pages/SignupPage.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { MapPin, Gift, Eye, EyeOff, CheckCircle, AlertCircle } from 'lucide-react';
+import { API_URL } from '../config';
 
 // Types for the component
 interface LocationData {
@@ -104,7 +105,7 @@ const SignupPage: React.FC = () => {
 
     setPromoStatus('validating');
     try {
-      const response = await fetch('http://localhost:4000/api/auth/validate-promo-public', {
+      const response = await fetch(`${API_URL}/auth/validate-promo-public`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- centralize API URL configuration
- import new `API_URL` constant across frontend
- document how to override backend URL in `.env`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6840e8868aa8832cb3913d56b0abfb8d